### PR TITLE
Add cross-platform tests, remove lockfile

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,23 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [20]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ getDirs('./test/testDirectory', ['folderB'], stream => {
 })
 ```
 
-Tested on Mac OSX only so far.
+The library is tested automatically on macOS, Windows and Linux via GitHub Actions.
 
 **note**: prior versions of this package used `instanceof RegExp` to validate the
 `exclude` argument. In some versions of the Node REPL each expression is

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon ./test/index.js -x 'npm test'",
-    "test": "node ./test/index.js | faucet"
+    "test": "node -e \"require('./test/index.js'); require('./test/windows.js');\" | faucet"
   },
   "repository": {
     "type": "git",
@@ -32,6 +32,7 @@
   "devDependencies": {
     "callback-stream": "^1.1.0",
     "faucet": "0.0.1",
+    "mock-fs": "^5.5.0",
     "tape": "^4.6.3"
   }
 }

--- a/test/windows.js
+++ b/test/windows.js
@@ -1,0 +1,41 @@
+const tape = require('tape');
+const mock = require('mock-fs');
+const stream = require('stream');
+const callbackStream = require('callback-stream');
+
+// Only run on Windows
+const isWin = process.platform === 'win32';
+const test = isWin ? tape : tape.skip;
+const getDirs = require('../index');
+
+const rootDir = 'C:/testDir';
+
+const mockConfig = {
+  'C:/testDir/folderA': {
+    'folderAA': {}
+  },
+  'C:/testDir/folderB': {}
+};
+
+test('getDirs works on Windows paths', t => {
+  mock(mockConfig);
+
+  getDirs(rootDir, [], readableStream => {
+    t.true(readableStream instanceof stream.Readable);
+
+    readableStream.pipe(
+      callbackStream((err, dirs) => {
+        t.deepEqual(
+          dirs.map(d => d.toString()),
+          [
+            'C:/testDir/folderA',
+            'C:/testDir/folderB',
+            'C:/testDir/folderA/folderAA'
+          ]
+        );
+        mock.restore();
+        t.end();
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Windows test using `mock-fs`
- run GitHub Actions tests on Ubuntu, macOS, and Windows
- document automatic cross-platform testing in README
- remove accidentally committed `package-lock.json` and ignore it

## Testing
- `npm install --no-package-lock`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684acc9e56e483278183667f9a6abc01